### PR TITLE
Fix: 채팅 소켓을 닫은 후 sendPing이 호출되어 오류 나는 이슈 해결

### DIFF
--- a/src/chat/chat.ts
+++ b/src/chat/chat.ts
@@ -397,6 +397,7 @@ export class ChzzkChat {
     }
 
     private sendPing() {
+        if (!this.ws) return;
         this.ws.send(JSON.stringify({
             cmd: ChatCmd.PING,
             ver: "2"


### PR DESCRIPTION
disconnect 매소드를 이용해 소켓의 연결을 닫았음에도 sendPing에 대한 타임아웃이 클리되 되지 않아 아래와 같은 오류가 발생하고 있습니다.

웹 소켓이 닫힌 경우 sendPing이 발송되지 않도록 수정하였습니다.

```
this.ws.send(JSON.stringify({
                ^

TypeError: Cannot read properties of null (reading 'send')
    at ChzzkChat.sendPing (C:\Bitnami\web\Dochis\ssapi\node_modules\chzzk\dist\chat\chat.js:326:17)
    at Timeout._onTimeout (C:\Bitnami\web\Dochis\ssapi\node_modules\chzzk\dist\chat\chat.js:330:52)
    at listOnTimeout (node:internal/timers:573:17)
    at process.processTimers (node:internal/timers:514:7)

Node.js v20.9.0
```