### PR TITLE
fix: attempting to disconnect even if _connected is false

### DIFF
--- a/src/chat/chat.ts
+++ b/src/chat/chat.ts
@@ -166,8 +166,10 @@ export class ChzzkChat {
     async reconnect() {
         this.isReconnect = true
 
-        await this.disconnect()
-        await this.connect()
+        if (this._connected) {
+            await this.disconnect()
+            await this.connect()
+        }
     }
 
     requestRecentChat(count: number = 50) {


### PR DESCRIPTION
간헐적으로 polling에 의해 자동으로 reconnect될 때 발생하는 Not connected 문제를 해결하기 위한 커밋입니다. (throw Error로 인해 강제로 종료되는 문제 해결)