### PR TITLE
fix: add error handling for age-restricted broadcasts

### DIFF
--- a/src/api/chat.ts
+++ b/src/api/chat.ts
@@ -19,6 +19,11 @@ export interface BlindOptions {
 export async function accessToken(client: ChzzkClient, chatChannelId: string) {
     const r = await client.fetch(`${client.options.baseUrls.gameBaseUrl}/v1/chats/access-token?channelId=${chatChannelId}&chatType=STREAMING`)
     const data = await r.json()
+
+    if (data['code'] === 42601) {
+        throw new Error('Broadcast is age-restricted, nidAuth, nidSession is required')
+    }
+
     return data['content'] ?? null
 }
 


### PR DESCRIPTION
에러 메시지
Before:
```
TypeError: Cannot read properties of null (reading 'accessToken')
    at /Users/.../Projects/OtherProjects/chzzk/src/chat/chat.ts:94:38
    at processTicksAndRejections (node:internal/process/task_queues:95:5)
```

After: 
```
Error: Channel is adult content, nidAuth, nidSession is required
    at /Users/.../Projects/OtherProjects/chzzk/src/api/chat.ts:24:15
    at Generator.next (<anonymous>)
    at fulfilled (/Users/.../Projects/OtherProjects/chzzk/src/api/chat.ts:5:58)
    at processTicksAndRejections (node:internal/process/task_queues:95:5)
```
