### PR TITLE
방송 정보, 카테고리 등에 대한 업데이트

### DIFF
--- a/src/api/live.ts
+++ b/src/api/live.ts
@@ -138,7 +138,7 @@ export interface LiveDetail extends BaseLive {
     chatDonationRankingExposure: boolean
     adParameter: {
         tag: string // unknown
-    },
+    }
     dropsCampaignNo?: string // unknown
 }
 

--- a/src/api/live.ts
+++ b/src/api/live.ts
@@ -96,6 +96,7 @@ export interface LiveStatus {
     accumulateCount: number
     paidPromotion: boolean
     adult: boolean
+    krOnlyViewing: boolean
     chatChannelId: string
     tags: string[]
     categoryType: string
@@ -104,12 +105,13 @@ export interface LiveStatus {
     livePollingStatus: LivePollingStatus
     faultStatus?: string // unknown
     userAdultStatus?: string
+    blindType?: string // unknown
     chatActive: boolean
     chatAvailableGroup: string
     chatAvailableCondition: string
     minFollowerMinute: number
     chatDonationRankingExposure: boolean
-    dropsCampaignNo: string // unknown
+    dropsCampaignNo?: string // unknown
     liveTokenList: string[] // unknown
 }
 
@@ -137,7 +139,7 @@ export interface LiveDetail extends BaseLive {
     adParameter: {
         tag: string // unknown
     },
-    dropsCampaignNo: string // unknown
+    dropsCampaignNo?: string // unknown
 }
 
 export class ChzzkLive {

--- a/src/api/live.ts
+++ b/src/api/live.ts
@@ -109,6 +109,8 @@ export interface LiveStatus {
     chatAvailableCondition: string
     minFollowerMinute: number
     chatDonationRankingExposure: boolean
+    dropsCampaignNo: string // unknown
+    liveTokenList: string[] // unknown
 }
 
 export interface LivePollingStatus {
@@ -134,7 +136,8 @@ export interface LiveDetail extends BaseLive {
     chatDonationRankingExposure: boolean
     adParameter: {
         tag: string // unknown
-    }
+    },
+    dropsCampaignNo: string // unknown
 }
 
 export class ChzzkLive {

--- a/src/api/manage.ts
+++ b/src/api/manage.ts
@@ -28,12 +28,13 @@ export interface LiveSettingParams {
     chatDonationRankingExposure: boolean
     tags: string[]
     clipActive: boolean
+    replayPublishType: string
 }
 
 export interface LiveSetting {
     defaultLiveTitle: string
     category: {
-        categoryType?: "GAME" | "ETC"
+        categoryType?: string
         categoryId?: string
         categoryValue?: string
         posterImageUrl?: string
@@ -49,6 +50,8 @@ export interface LiveSetting {
     chatDonationRankingExposure: boolean
     tags: string[]
     clipActive: boolean
+    replayPublishType: string
+    dropsCampaignNo: string
 }
 
 export interface ChatRule {

--- a/src/api/manage.ts
+++ b/src/api/manage.ts
@@ -39,19 +39,21 @@ export interface LiveSetting {
         categoryValue?: string
         posterImageUrl?: string
         tags?: string[]
+        dropsCampaignNos?: string[]
     }
     defaultThumbnailImageUrl?: string
     chatActive: boolean
     chatAvailableGroup: string
     paidPromotion: boolean
     adult: boolean
+    krOnlyViewing: boolean
     chatAvailableCondition: string
     minFollowerMinute: number
     chatDonationRankingExposure: boolean
     tags: string[]
     clipActive: boolean
     replayPublishType: string
-    dropsCampaignNo: string
+    dropsCampaignNo?: string
 }
 
 export interface ChatRule {

--- a/src/api/manage.ts
+++ b/src/api/manage.ts
@@ -22,6 +22,8 @@ export interface LiveSettingParams {
     chatAvailableCondition: string
     defaultLiveTitle: string
     defaultThumbnailImageUrl?: string
+    dropsCampaignNo?: string
+    krOnlyViewing: boolean
     liveCategory?: string
     paidPromotion: boolean
     minFollowerMinute: number

--- a/src/api/search.ts
+++ b/src/api/search.ts
@@ -69,6 +69,19 @@ export interface Lounge {
     officialLounge: boolean
 }
 
+export interface CategorySearchResult {
+    results: Category[]
+}
+
+export interface Category {
+    categoryType: string
+    categoryId: string
+    categoryValue: string
+    posterImageUrl: string
+    tags: string[]
+    dropsCampaignNos: string[]
+}
+
 export class ChzzkSearch {
     private client: ChzzkClient
 
@@ -163,6 +176,21 @@ export class ChzzkSearch {
         }).toString()
 
         return this.client.fetch(`${this.client.options.baseUrls.gameBaseUrl}/v2/search/lounges?${params}`)
+            .then(r => r.json())
+            .then(data => data['content'])
+    }
+
+    async categories(
+        keyword: string,
+        options: SearchOptions = DEFAULT_SEARCH_OPTIONS
+    ): Promise<CategorySearchResult> {
+        const params = new URLSearchParams({
+            keyword,
+            size: options.size.toString(),
+            offset: options.offset.toString()
+        }).toString()
+
+        return this.client.fetch(`${this.client.options.baseUrls.chzzkBaseUrl}/manage/v1/auto-complete/categories?${params}`)
             .then(r => r.json())
             .then(data => data['content'])
     }


### PR DESCRIPTION
categories 함수를 추가했습니다. (/api/search.ts)
API는 manage쪽에 있긴 하지만 search쪽에 더 연관된 것 같아 search쪽으로 옮겼습니다.

```js
await client.search.categories("DJMAX RESPECT V");
```

↓

```json
{
    "results": [
        {
            "categoryType": "GAME",
            "categoryId": "DJMAX_RESPECT_V",
            "categoryValue": "디제이맥스 리스펙트 V",
            "posterImageUrl": "https://nng-phinf.pstatic.net/MjAyNDAyMjZfMjAx/MDAxNzA4OTM2MzIxMTY2.exnO6z7ZvUOw2fU5Ar08S3mcNnq36hbs_uaMf7vJc4kg.Y3soPurHhdzvscvAQ-L-X6gwP9fzwq1QXna2ZAlH0HAg.PNG/%EB%94%94%EC%A0%9C%EC%9D%B4%EB%A7%A5%EC%8A%A4.png",
            "tags": [
                "디제이맥스 리스펙트 V",
                "리듬",
                "PC",
                "네오위즈"
            ],
            "dropsCampaignNos": []
        }
    ]
}
```

왜 추가했는가?
-> 기존에 사용했던 lounges에서는 `categoryType`을 리턴해주지 않고, `originalLoungeId`와 `loungeId`가 같은 카테고리도 있고 다른 카테고리도 있어 (`프로젝트 세카이 컬러풀 스테이지! feat.하츠네 미쿠` -> `originalLoungeId`: `Project_SEKAI_COLORFUL_STAGE`, `loungeId`: `pjsekai`, 이 중 `originalLoungeId`를 사용해야 하지만, `디제이맥스 리스펙트 V`와 같은 대부분의 카테고리의 경우 -> `originalLoungeId`: `DJMAX_RESPECT_V`, `loungeId`: `DJMAX_RESPECT_V`로 둘 다 같아 혼동하기 쉽습니다.) 추가했습니다.

이외 `LiveDetail`, `LiveStatus`, `LiveSettingParams`, `LiveSetting`에 드롭스, 한국 전용 시청 등의 key등을 추가했습니다.
`LiveSetting`에서의 categoryType은 기존 `GAME`과 `ETC`에서 `SPORTS`까지 추가됨에 따라 더 추가될 것을 방지하기 위해 type을 `string`으로 수정했습니다. 