### PR TITLE
Issue Fix: nullreferenceexception 이슈

### DIFF
--- a/src/chat/chat.ts
+++ b/src/chat/chat.ts
@@ -101,7 +101,7 @@ export class ChzzkChat {
         }
 
         if(!this.options.chatChannelId){
-            return this.emit('NoChatChannelId', yield this.client.live.status(this.options.channelId));
+            return this.emit('NoChatChannelId', await this.client.live.status(this.options.channelId));
         }
 
         const serverId = Math.abs(

--- a/src/chat/chat.ts
+++ b/src/chat/chat.ts
@@ -101,7 +101,8 @@ export class ChzzkChat {
         }
 
         if(!this.options.chatChannelId){
-            return this.emit('NoChatChannelId', await this.client.live.status(this.options.channelId));
+            this.emit('NoChatChannelId', await this.client.live.status(this.options.channelId));
+            throw new Error('chatChannelId is null. Please ensure it is set before connecting.');
         }
 
         const serverId = Math.abs(

--- a/src/chat/chat.ts
+++ b/src/chat/chat.ts
@@ -101,7 +101,6 @@ export class ChzzkChat {
         }
 
         if(!this.options.chatChannelId){
-            this.emit('NoChatChannelId', await this.client.live.status(this.options.channelId));
             throw new Error('chatChannelId is null. Please ensure it is set before connecting.');
         }
 

--- a/src/chat/chat.ts
+++ b/src/chat/chat.ts
@@ -100,6 +100,10 @@ export class ChzzkChat {
             ver: "2"
         }
 
+        if(!this.options.chatChannelId){
+            return this.emit('NoChatChannelId', yield this.client.live.status(this.options.channelId));
+        }
+
         const serverId = Math.abs(
             this.options.chatChannelId.split("")
                 .map(c => c.charCodeAt(0))


### PR DESCRIPTION
경로: src/chat.ts

이슈: 특정 스트리머의 경우 chatChannelId 값이 없는경우가 간헐적으로 있음.
 `        const serverId = Math.abs(
            this.options.chatChannelId.split("")
                .map(c => c.charCodeAt(0))
                .reduce((a, b) => a + b)
        ) % 9 + 1`
107번 라인의 위 코드에서 참조에러 (this.options.chatChannelId 이 null 인데 split을 사용함)

조치: 
`
        if(!this.options.chatChannelId){
            return this.emit('NoChatChannelId', await this.client.live.status(this.options.channelId));
        }
`
this.options.chatChannelId 값이 없을때, return 하였습니다. 
this.emit을 통해 소켓으로 해당 스트리머의 status 값도 넘겨받을수 있도록 수정하였습니다.